### PR TITLE
[WIP] Integrate with go-get package

### DIFF
--- a/lib/gorename.js
+++ b/lib/gorename.js
@@ -5,13 +5,26 @@ import {CompositeDisposable, Point} from 'atom'
 import {RenameDialog} from './rename-dialog'
 
 class Gorename {
-  constructor (goconfigFunc) {
+  constructor (goconfigFunc, gogetFunc) {
     this.goconfig = goconfigFunc
+    this.goget = gogetFunc
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(atom.commands.add(
       'atom-text-editor', 'gorename:rename',
       () => this.commandInvoked())
     )
+  }
+
+  checkForTool () {
+    let get = this.goget()
+    if (get) {
+      get.get({
+        name: 'gorename',
+        packageName: 'gorename',
+        packagePath: 'golang.org/x/tools/cmd/gorename',
+        type: 'missing' // TODO check whether missing or outdated
+      })
+    }
   }
 
   commandInvoked () {
@@ -101,6 +114,7 @@ class Gorename {
     this.subscriptions.dispose()
     this.subscriptions = null
     this.goconfig = null
+    this.goget = null
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,12 +4,16 @@ import {CompositeDisposable} from 'atom'
 import {Gorename} from './gorename'
 
 export default {
-  golangconfig: null,
+  goconfig: null,
+  goget: null,
   subscriptions: null,
   dependenciesInstalled: null,
 
   activate () {
-    this.gorename = new Gorename(() => { return this.getGoconfig() })
+    this.gorename = new Gorename(
+      () => { return this.getGoconfig() },
+      () => { return this.getGoget() },
+    )
     this.subscriptions = new CompositeDisposable()
     require('atom-package-deps').install('gorename').then(() => {
       this.dependenciesInstalled = true
@@ -24,6 +28,7 @@ export default {
     }
     this.subscriptions = null
     this.goconfig = null
+    this.goget = null
     this.dependenciesInstalled = null
   },
 
@@ -34,7 +39,21 @@ export default {
     return false
   },
 
+  getGoget () {
+    if (this.goget) {
+      return this.goget
+    }
+    return false
+  },
+
   consumeGoconfig (service) {
     this.goconfig = service
+  },
+
+  consumeGoGet (service) {
+    this.goget = service
+    if (this.gorename) {
+      this.gorename.checkForTool()
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,18 @@
     "temp": "^0.8.3"
   },
   "package-deps": [
-    "go-config"
+    "go-config",
+    "go-get"
   ],
   "consumedServices": {
     "go-config": {
       "versions": {
         "0.1.0": "consumeGoconfig"
+      }
+    },
+    "go-get": {
+      "versions": {
+        "0.1.0": "consumeGoGet"
       }
     }
   }


### PR DESCRIPTION
Use the `go-get` package to automatically fetch/update the `gorename` tool.
- [x] Figure out why consume function isn't being called
- [ ] Use `go-get`'s `check` functionality to see if an update is available
- [ ] Determine when to check for the tool.  (on activation, first command invocation, when a go project is opened, etc.)
