### PR TITLE
Support renaming files when the $GOPATH has symlinks in it

### DIFF
--- a/lib/gorename.js
+++ b/lib/gorename.js
@@ -30,7 +30,14 @@ class Gorename {
 
       let dialog = new RenameDialog(info.word, (newName) => {
         this.saveAllEditors()
-        let file = editor.getBuffer().getPath()
+
+        // Pass raw path to gorename to avoid following symlinks. Let gorename decide what to do.
+        // Some people symlink their $GOPATH and it's important that gorename see the links.
+        //
+        // Details: editor.getPath() returns fully qualified paths, following symlinks,
+        // not what we want. relativizePath() returns the raw path project path and raw relative
+        // path that you see concatenated in the window title.
+        let file = path.join.apply(null, atom.project.relativizePath(editor.getPath()))
         let cwd = path.dirname(file)
 
         // restore cursor position after gorename completes and the buffer is reloaded


### PR DESCRIPTION
My `$GOPATH` looks like this: `/Users/jspiro/.go/personal:/Users/jspiro/.go/work` where personal and work are symlinks.

Atom's getPath() tends to normalize the path, passing a different one than seen in the window title. gorename doesn't work in that case. So I'm passing the raw path that's seen in the window title.
